### PR TITLE
Fix a typo

### DIFF
--- a/examples/DYN_EOF.ipynb
+++ b/examples/DYN_EOF.ipynb
@@ -284,7 +284,7 @@
     }
    ],
    "source": [
-    "n = 100\n",
+    "q = 100\n",
     "xi,yi = np.meshgrid(np.linspace(0,15,q),np.linspace(0,15,q))\n",
     "\n",
     "vorti = DYN.zeta(xi,yi,lambdify((x,y),u)(xi,yi),lambdify((x,y),v)(xi,yi))\n",


### PR DESCRIPTION
In the example DYN_EOF.ipynb where Zeta is calculated (cell 284 in the latest commit [1e13488](https://github.com/OceanLabPy/OceanLab/commit/1e1348840ed8d8d11b61f638c0c5846e45cd6fdb) for DYN_EOF.ipynb), `n = 100` should be `q = 100`. Otherwise, `q` is not assigned while `n` is assigned but not used later in the notebook.    